### PR TITLE
Fix: support resizing from (top, left, bottom, right)

### DIFF
--- a/app.js
+++ b/app.js
@@ -61,6 +61,22 @@ window.onload = function () {
             }
         }).resizable({
             edges: { left: true, right: true, bottom: true, top: true },
+            listeners: {
+                move: function(event) {
+                  let { x, y } = event.target.dataset
+        
+                  x = (parseFloat(x) || 0) + event.deltaRect.left
+                  y = (parseFloat(y) || 0) + event.deltaRect.top
+        
+                  Object.assign(event.target.style, {
+                    width: `${event.rect.width}px`,
+                    height: `${event.rect.height}px`,
+                    transform: `translate(${x}px, ${y}px)`
+                  })
+        
+                  Object.assign(event.target.dataset, { x, y })
+                }
+            },
             margin: 10
         });
 

--- a/styles.css
+++ b/styles.css
@@ -47,6 +47,7 @@ body {
 }
 
 .note {
+    box-sizing: border-box;
     touch-action: none;
     width: 200px;
     padding: 10px;


### PR DESCRIPTION
支持拖拽便利贴的四周边缘来调节大小（原先只支持拖拽右下角）